### PR TITLE
Include Content-Type header in Pennsieve requests

### DIFF
--- a/service/internal/test/mock/expectedcalls.go
+++ b/service/internal/test/mock/expectedcalls.go
@@ -33,6 +33,7 @@ func (e *ExpectedAPICall[I, _]) HandlerFunction(t *testing.T) func(http.Response
 	return func(writer http.ResponseWriter, request *http.Request) {
 		e.callCount += 1
 		require.Equal(t, e.Method, request.Method, "expected method %s for %s, got %s", e.Method, request.URL, request.Method)
+		require.Equal(t, "application/json", request.Header.Get("Content-Type"))
 		if e.ExpectedRequestBody == nil {
 			var requestBodyBytes []byte
 			_, err := request.Body.Read(requestBodyBytes)

--- a/service/pennsieve/invoke.go
+++ b/service/pennsieve/invoke.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 )
 
+const ApplicationJSON = "application/json"
+
 type Session struct {
 	Token    string
 	APIHost  string
@@ -32,7 +34,8 @@ func (s *Session) newPennsieveRequest(method string, url string, structBody any)
 	if err != nil {
 		return nil, fmt.Errorf("error creating %s %s request: %w", method, url, err)
 	}
-	request.Header.Add("accept", "application/json")
+	request.Header.Add("accept", ApplicationJSON)
+	request.Header.Add("Content-Type", ApplicationJSON)
 	request.Header.Add("Authorization", fmt.Sprintf("Bearer %s", s.Token))
 	return request, nil
 }


### PR DESCRIPTION
The model service returns 415 if the request does not include a `Content-Type` header with `application/json`.
This PR adds that header to all requests.
