### PR TITLE
Add Model Deletes

### DIFF
--- a/client/clienttest/models.go
+++ b/client/clienttest/models.go
@@ -9,8 +9,8 @@ import (
 	"math/rand"
 )
 
-func NewModelCreate() models.ModelCreate {
-	return models.ModelCreate{
+func NewModelCreate() models.ModelCreateParams {
+	return models.ModelCreateParams{
 		Name:        uuid.NewString(),
 		DisplayName: uuid.NewString(),
 		Description: uuid.NewString(),
@@ -18,10 +18,10 @@ func NewModelCreate() models.ModelCreate {
 	}
 }
 
-func NewPropertyCreateSimple(t require.TestingT, dataType datatypes.SimpleType) models.PropertyCreate {
+func NewPropertyCreateSimple(t require.TestingT, dataType datatypes.SimpleType) models.PropertyCreateParams {
 	bytes, err := json.Marshal(dataType)
 	require.NoError(t, err)
-	return models.PropertyCreate{
+	return models.PropertyCreateParams{
 		DisplayName:  uuid.NewString(),
 		Name:         uuid.NewString(),
 		DataType:     bytes,
@@ -36,10 +36,10 @@ func NewArrayDataType(itemType datatypes.SimpleType) datatypes.ArrayDataType {
 		Items: datatypes.ItemsType{Type: itemType},
 	}
 }
-func NewPropertyCreateArray(t require.TestingT, itemType datatypes.SimpleType) models.PropertyCreate {
+func NewPropertyCreateArray(t require.TestingT, itemType datatypes.SimpleType) models.PropertyCreateParams {
 	dataTypeBytes, err := json.Marshal(NewArrayDataType(itemType))
 	require.NoError(t, err)
-	return models.PropertyCreate{
+	return models.PropertyCreateParams{
 		DisplayName:  uuid.NewString(),
 		Name:         uuid.NewString(),
 		DataType:     dataTypeBytes,

--- a/client/models/dataset.go
+++ b/client/models/dataset.go
@@ -1,7 +1,7 @@
 package models
 
 type Dataset struct {
-	Models             []ModelChanges               `json:"models"`
+	Models             ModelChanges                 `json:"models"`
 	LinkedProperties   []LinkedPropertyChanges      `json:"linked_properties"`
 	Proxies            *ProxyChanges                `json:"proxies"`
 	ExistingModelIDMap map[string]PennsieveSchemaID `json:"existing_model_id_map"`

--- a/client/models/model.go
+++ b/client/models/model.go
@@ -29,25 +29,50 @@ type ModelChanges struct {
 	Create *ModelPropsCreate `json:"create,omitempty"`
 	// Records describes the changes to the records of this model type
 	Records RecordChanges `json:"records"`
+
+	Creates []ModelCreate `json:"creates"`
+	Updates []ModelUpdate `json:"updates"`
+	Deletes []ModelDelete `json:"deletes"`
+}
+
+type ModelCreate struct {
+	// Create contains the params necessary to create the model and its (non-link) properties
+	Create ModelPropsCreate `json:"create"`
+	// Records are records that should be created
+	Records []RecordCreate `json:"records"`
+}
+
+type ModelUpdate struct {
+	// The ID of the model in Pennsieve.
+	ID PennsieveSchemaID `json:"id"`
+	// Records describes the changes to the records of this model type
+	Records RecordChanges `json:"records"`
+}
+
+type ModelDelete struct {
+	// The ID of the model in Pennsieve.
+	ID PennsieveSchemaID `json:"id"`
+	// A list of RecordIDs to delete. All records must be deleted in order to delete a model
+	Records []PennsieveInstanceID `json:"records"`
 }
 
 type ModelPropsCreate struct {
-	Model      ModelCreate      `json:"model"`
-	Properties PropertiesCreate `json:"properties"`
+	Model      ModelCreateParams      `json:"model"`
+	Properties PropertiesCreateParams `json:"properties"`
 }
 
-// ModelCreate can be used as a payload for POST /models/datasets/<dataset id>/concepts to create a model
-type ModelCreate struct {
+// ModelCreateParams can be used as a payload for POST /models/datasets/<dataset id>/concepts to create a model
+type ModelCreateParams struct {
 	Name        string `json:"name"`
 	DisplayName string `json:"displayName"`
 	Description string `json:"description"`
 	Locked      bool   `json:"locked"`
 }
 
-// PropertiesCreate can be uses as a payload for PUT /models/datasets/<dataset id>/concepts/<model id>/properties to add properties to a model
-type PropertiesCreate []PropertyCreate
+// PropertiesCreateParams can be uses as a payload for PUT /models/datasets/<dataset id>/concepts/<model id>/properties to add properties to a model
+type PropertiesCreateParams []PropertyCreateParams
 
-type PropertyCreate struct {
+type PropertyCreateParams struct {
 	DisplayName  string          `json:"displayName"`
 	Name         string          `json:"name"`
 	DataType     json.RawMessage `json:"dataType"`
@@ -61,7 +86,7 @@ type PropertyCreate struct {
 	Description  string          `json:"description"`
 }
 
-func (pc *PropertyCreate) SetDataType(dataType any) error {
+func (pc *PropertyCreateParams) SetDataType(dataType any) error {
 	bytes, err := json.Marshal(dataType)
 	if err != nil {
 		return fmt.Errorf("error marshalling data type: %w", err)

--- a/client/models/model.go
+++ b/client/models/model.go
@@ -22,14 +22,6 @@ type PennsieveInstanceID string
 type ExternalInstanceID string
 
 type ModelChanges struct {
-	// The ID of the model. Can be empty or missing if the model does not exist.
-	// In this case, Create below should be non-nil
-	ID PennsieveSchemaID `json:"id,omitempty"`
-	// If Create is non-nil, the model should be created
-	Create *ModelPropsCreate `json:"create,omitempty"`
-	// Records describes the changes to the records of this model type
-	Records RecordChanges `json:"records"`
-
 	Creates []ModelCreate `json:"creates"`
 	Updates []ModelUpdate `json:"updates"`
 	Deletes []ModelDelete `json:"deletes"`

--- a/service/internal/test/mock/expectedcalls/models.go
+++ b/service/internal/test/mock/expectedcalls/models.go
@@ -9,8 +9,8 @@ import (
 	"net/http"
 )
 
-func ModelCreate(expectedDatasetID string, modelID clientmodels.PennsieveSchemaID, expectedCreate clientmodels.ModelCreate) *mock.ExpectedAPICall[clientmodels.ModelCreate, models.APIResponse] {
-	return &mock.ExpectedAPICall[clientmodels.ModelCreate, models.APIResponse]{
+func ModelCreate(expectedDatasetID string, modelID clientmodels.PennsieveSchemaID, expectedCreate clientmodels.ModelCreateParams) *mock.ExpectedAPICall[clientmodels.ModelCreateParams, models.APIResponse] {
+	return &mock.ExpectedAPICall[clientmodels.ModelCreateParams, models.APIResponse]{
 		Method:              http.MethodPost,
 		APIPath:             fmt.Sprintf("/models/datasets/%s/concepts", expectedDatasetID),
 		ExpectedRequestBody: &expectedCreate,
@@ -21,7 +21,7 @@ func ModelCreate(expectedDatasetID string, modelID clientmodels.PennsieveSchemaI
 	}
 }
 
-func PropertiesCreate(expectedDatasetID string, modelID clientmodels.PennsieveSchemaID, expectedCreate clientmodels.PropertiesCreate) *mock.ExpectedAPICall[clientmodels.PropertiesCreate, []models.APIResponse] {
+func PropertiesCreate(expectedDatasetID string, modelID clientmodels.PennsieveSchemaID, expectedCreate clientmodels.PropertiesCreateParams) *mock.ExpectedAPICall[clientmodels.PropertiesCreateParams, []models.APIResponse] {
 	var apiResponse []models.APIResponse
 	for _, prop := range expectedCreate {
 		apiResponse = append(apiResponse, models.APIResponse{
@@ -29,7 +29,7 @@ func PropertiesCreate(expectedDatasetID string, modelID clientmodels.PennsieveSc
 			ID:   uuid.NewString(),
 		})
 	}
-	return &mock.ExpectedAPICall[clientmodels.PropertiesCreate, []models.APIResponse]{
+	return &mock.ExpectedAPICall[clientmodels.PropertiesCreateParams, []models.APIResponse]{
 		Method:              http.MethodPut,
 		APIPath:             fmt.Sprintf("/models/datasets/%s/concepts/%s/properties", expectedDatasetID, modelID),
 		ExpectedRequestBody: &expectedCreate,

--- a/service/pennsieve/models.go
+++ b/service/pennsieve/models.go
@@ -21,7 +21,7 @@ func (s *Session) CreateModelAndProps(datasetID string, modelPropsCreate clientm
 	return modelID, nil
 }
 
-func (s *Session) CreateModel(datasetID string, modelCreate clientmodels.ModelCreate) (clientmodels.PennsieveSchemaID, error) {
+func (s *Session) CreateModel(datasetID string, modelCreate clientmodels.ModelCreateParams) (clientmodels.PennsieveSchemaID, error) {
 	url := fmt.Sprintf("%s/models/datasets/%s/concepts", s.APIHost, datasetID)
 	response, err := s.InvokePennsieve(http.MethodPost, url, modelCreate)
 	if err != nil {
@@ -34,7 +34,16 @@ func (s *Session) CreateModel(datasetID string, modelCreate clientmodels.ModelCr
 	return clientmodels.PennsieveSchemaID(apiResponse.ID), nil
 }
 
-func (s *Session) CreateModelProperties(datasetID string, modelID clientmodels.PennsieveSchemaID, propsCreate clientmodels.PropertiesCreate) error {
+func (s *Session) DeleteModel(datasetID string, modelID clientmodels.PennsieveSchemaID) error {
+	url := fmt.Sprintf("%s/models/datasets/%s/concepts/%s", s.APIHost, datasetID, modelID)
+	_, err := s.InvokePennsieve(http.MethodDelete, url, nil)
+	if err != nil {
+		return fmt.Errorf("error deleting model %s: %w", modelID, err)
+	}
+	return nil
+}
+
+func (s *Session) CreateModelProperties(datasetID string, modelID clientmodels.PennsieveSchemaID, propsCreate clientmodels.PropertiesCreateParams) error {
 	if len(propsCreate) == 0 {
 		return nil
 	}

--- a/service/processor/processor.go
+++ b/service/processor/processor.go
@@ -58,7 +58,7 @@ func (p *MetadataPostProcessor) Run() error {
 	if err := p.ProcessDeletes(datasetID, datasetChanges); err != nil {
 		return err
 	}
-	if err := p.ProcessModels(datasetID, datasetChanges.Models); err != nil {
+	if err := p.ProcessModelCreatesUpdates(datasetID, datasetChanges.Models.Creates, datasetChanges.Models.Updates); err != nil {
 		return err
 	}
 	// Wait til after ProcessModels to add these so that the IDStore now should have the complete mapping
@@ -88,7 +88,7 @@ func (p *MetadataPostProcessor) ProcessDeletes(datasetID string, datasetChanges 
 			return err
 		}
 	}
-	if err := p.ProcessRecordDeletes(datasetID, datasetChanges.Models); err != nil {
+	if err := p.ProcessRecordModelDeletes(datasetID, datasetChanges.Models.Updates, datasetChanges.Models.Deletes); err != nil {
 		return err
 	}
 	logger.Info("finished deletes")

--- a/service/processor/processor_test.go
+++ b/service/processor/processor_test.go
@@ -61,7 +61,7 @@ func testCreateModelAndRecord(t *testing.T) {
 
 	modelCreate := clienttest.NewModelCreate()
 
-	propertiesCreate := clientmodels.PropertiesCreate{
+	propertiesCreate := clientmodels.PropertiesCreateParams{
 		clienttest.NewPropertyCreateSimple(t, datatypes.StringType),
 		clienttest.NewPropertyCreateArray(t, datatypes.DoubleType),
 	}
@@ -75,21 +75,19 @@ func testCreateModelAndRecord(t *testing.T) {
 	createdRecordExternalID := clienttest.NewExternalInstanceID()
 
 	changeset := clientmodels.Dataset{
-		Models: []clientmodels.ModelChanges{
-			{
-				Create: &clientmodels.ModelPropsCreate{
+		Models: clientmodels.ModelChanges{
+			Creates: []clientmodels.ModelCreate{{
+				Create: clientmodels.ModelPropsCreate{
 					Model:      modelCreate,
 					Properties: propertiesCreate,
 				},
-				Records: clientmodels.RecordChanges{
-					Create: []clientmodels.RecordCreate{
-						{
-							ExternalID:   createdRecordExternalID,
-							RecordValues: recordCreateValues,
-						},
+				Records: []clientmodels.RecordCreate{
+					{
+						ExternalID:   createdRecordExternalID,
+						RecordValues: recordCreateValues,
 					},
 				},
-			},
+			}},
 		},
 	}
 	changesetFilePath := processor.ChangesetFilePath(outputDirectory)


### PR DESCRIPTION
PR refactors the changeset models and adds the ability to delete a model.

If a model is being deleted, the `ModelDelete` JSON must include the instance ids of all records of that model.

The model service automatically deletes any linked property or relationship schemas that the model takes part in.